### PR TITLE
feat: exports types from exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/markdown.cjs.min.js",
-      "import": "./dist/markdown.esm.min.js"
+      "import": "./dist/markdown.esm.min.js",
+      "types": "./types/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Hi! Thank you for your awesome package!
I found that there is an error like **no type found for linkToCardPlugin**, and when I add type field to exports filed in package.json, it works fine!
Related commit in my project: https://github.com/ryoppippi/ryoppippi.com/commit/91b070c216833d1286b998b2c85a43f7b4ce8424

Please review this! @luckrya @cllemon 